### PR TITLE
Fix readme markup syntax so h2 is rendered correctly in Github.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ __GONMarkupParser_All.h__ will reference all library headers, whereas __GONMarku
 - instantiate a new __GONMarkupParser__ or use the  __+ GONMarkupParserManager sharedParser__ one.
 - configure your parser adding supported tags, default ones, custom ones, etc...
 - parse input string and retrieve result __NSMutableAttributedString__ using __- attributedStringFromString:error:__ method from __GONMarkupParser__
-- you can also set text on __UILabel__ / __UITextField__ / __UITextView__ by using [__setMarkedUpText:__](#available-uikit-categories) methods 
+- you can also set text on __UILabel__ / __UITextField__ / __UITextView__ by using [__setMarkedUpText:__](#available-uikit-categories) methods
+
 ##How does it work ?
 ![ScreenShot](https://raw.github.com/nicolasgoutaland/GONMarkupParser/master/Assets/GONMarkupParser-howdoesitworks.gif)
 


### PR DESCRIPTION
Before:

![screen shot 2015-02-11 at 9 10 45 am](https://cloud.githubusercontent.com/assets/522951/6151910/f53837f8-b1cd-11e4-9944-5bb045960abf.png)

After:

![screen shot 2015-02-11 at 9 11 07 am](https://cloud.githubusercontent.com/assets/522951/6151912/f7bdcad8-b1cd-11e4-9f26-59d617eca977.png)
