### PR TITLE
font  add new tag attribute

### DIFF
--- a/Classes/GONMarkupFont.h
+++ b/Classes/GONMarkupFont.h
@@ -28,6 +28,7 @@
 
 // Attributes
 #define GONMarkupFont_TAG_size_ATT       @"size"                // Is missing
+#define GONMarkupFont_TAG_color_ATT      @"color"               // text color
 #define GONMarkupFont_TAG_name_ATT       @"name"                // Full font name, including style
 
 @interface GONMarkupFont : GONMarkup

--- a/Classes/GONMarkupFont.m
+++ b/Classes/GONMarkupFont.m
@@ -25,6 +25,15 @@
 {
     NSString *value;
 
+    //Font color
+    if ([dicAttributes objectForKey:GONMarkupFont_TAG_color_ATT]) {
+        UIColor *colorValue = [[dicAttributes objectForKey:GONMarkupFont_TAG_color_ATT] representedColor];
+        if (colorValue)
+        {
+            [configurationDictionary setObject:colorValue forKey:NSForegroundColorAttributeName];
+        }
+    }
+    
     // Font name
     value = [dicAttributes objectForKey:GONMarkupFont_TAG_name_ATT];
     if (value)


### PR DESCRIPTION
in my opinion ,  `<font size="12" color="red">123</font>` more easy then `<font size="12"><color value="red">123</color></font>` ,So I suggest to support two implementation. 
